### PR TITLE
fix: resolve database locked error during sync

### DIFF
--- a/src/litlake/db.py
+++ b/src/litlake/db.py
@@ -26,12 +26,13 @@ def utc_now_iso() -> str:
 
 def connect_db(path: Path | str, *, read_only: bool = False) -> sqlite3.Connection:
     if read_only:
-        conn = sqlite3.connect(f"file:{Path(path)}?mode=ro", uri=True, check_same_thread=False)
+        conn = sqlite3.connect(f"file:{Path(path)}?mode=ro", uri=True, check_same_thread=False, timeout=30, isolation_level=None)
     else:
-        conn = sqlite3.connect(str(path), check_same_thread=False)
+        conn = sqlite3.connect(str(path), check_same_thread=False, timeout=30, isolation_level=None)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=30000;")
     conn.execute("PRAGMA journal_mode=WAL;")
-    conn.execute("PRAGMA busy_timeout=5000;")
+    conn.execute("PRAGMA locking_mode=NORMAL;")
     conn.execute("PRAGMA foreign_keys=ON;")
     _load_sqlite_vec(conn)
     return conn


### PR DESCRIPTION
Fixes #16

- Set isolation_level=None and timeout=30 on all connections
- Move busy_timeout PRAGMA before journal_mode=WAL
- Add locking_mode=NORMAL to release locks between transactions
- Move model loading outside conn_lock in _background_init
- Use dedicated connection with retry loop in sync_zotero_tool

Problem: sync_zotero fails with "database is locked" when background workers are running. This prevents both the automatic startup sync and manual sync tool calls.
Root cause: Python's sqlite3 module with default settings holds implicit transactions open, causing lock contention between the sync and worker connections. Additionally, model loading inside conn_lock in _background_init blocks the lock for too long on startup.
Fix:

Set isolation_level=None and timeout=30 on all connections
Move busy_timeout PRAGMA before journal_mode=WAL
Add locking_mode=NORMAL to release locks between transactions
Move model loading outside conn_lock in _background_init
Use dedicated connection with retry loop in sync_zotero_tool

Tested on: macOS, Zotero library with 409 references, 319 PDFs.