### PR TITLE
Feature/pdf annotations

### DIFF
--- a/src/litlake/db.py
+++ b/src/litlake/db.py
@@ -26,12 +26,13 @@ def utc_now_iso() -> str:
 
 def connect_db(path: Path | str, *, read_only: bool = False) -> sqlite3.Connection:
     if read_only:
-        conn = sqlite3.connect(f"file:{Path(path)}?mode=ro", uri=True, check_same_thread=False)
+        conn = sqlite3.connect(f"file:{Path(path)}?mode=ro", uri=True, check_same_thread=False, timeout=30, isolation_level=None)
     else:
-        conn = sqlite3.connect(str(path), check_same_thread=False)
+        conn = sqlite3.connect(str(path), check_same_thread=False, timeout=30, isolation_level=None)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=30000;")
     conn.execute("PRAGMA journal_mode=WAL;")
-    conn.execute("PRAGMA busy_timeout=5000;")
+    conn.execute("PRAGMA locking_mode=NORMAL;")
     conn.execute("PRAGMA foreign_keys=ON;")
     _load_sqlite_vec(conn)
     return conn
@@ -274,6 +275,63 @@ def init_db(conn: sqlite3.Connection) -> None:
             )
         else:
             raise
+
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS collections (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            zotero_collection_id INTEGER NOT NULL UNIQUE,
+            zotero_key TEXT NOT NULL UNIQUE,
+            name TEXT NOT NULL,
+            parent_zotero_collection_id INTEGER,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS collection_items (
+            collection_id INTEGER NOT NULL,
+            reference_id INTEGER NOT NULL,
+            PRIMARY KEY (collection_id, reference_id),
+            FOREIGN KEY(collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+            FOREIGN KEY(reference_id) REFERENCES reference_items(id) ON DELETE CASCADE
+        )
+        """
+    )
+    _ensure_index(conn, "CREATE INDEX IF NOT EXISTS idx_collection_items_reference ON collection_items(reference_id)")
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS collections (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            zotero_collection_id INTEGER UNIQUE,
+            zotero_key TEXT,
+            name TEXT NOT NULL,
+            parent_zotero_collection_id INTEGER,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS collection_items (
+            collection_id INTEGER NOT NULL,
+            reference_id INTEGER NOT NULL,
+            PRIMARY KEY (collection_id, reference_id),
+            FOREIGN KEY(collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+            FOREIGN KEY(reference_id) REFERENCES reference_items(id) ON DELETE CASCADE
+        )
+        """
+    )
+
+    _ensure_index(conn, "CREATE INDEX IF NOT EXISTS idx_collection_items_reference_id ON collection_items(reference_id)")
+
 
     conn.commit()
 

--- a/src/litlake/providers/chunking.py
+++ b/src/litlake/providers/chunking.py
@@ -199,6 +199,7 @@ class ChunkArtifact:
     content: str
     page_start: int | None = None
     page_end: int | None = None
+    rects: list[tuple[float, float, float, float]] | None = None  # bbox coords for Zotero annotations
 
 
 class ChunkingProvider(Protocol):
@@ -206,6 +207,38 @@ class ChunkingProvider(Protocol):
 
     def chunk(self, extraction: ExtractionResult) -> list[ChunkArtifact]:
         ...
+
+
+def _extract_rects_for_chunk(
+    chunk_text: str,
+    page_start: int | None,
+    page_end: int | None,
+    page_blocks: list[list[dict]],
+) -> list[tuple[float, float, float, float]] | None:
+    """Find bounding boxes in page_blocks that overlap with chunk_text."""
+    if page_start is None:
+        return None
+
+    chunk_words = set(chunk_text.lower().split())
+    rects: list[tuple[float, float, float, float]] = []
+
+    start_idx = (page_start - 1) if page_start else 0
+    end_idx = (page_end) if page_end else (page_start)
+    end_idx = min(end_idx, len(page_blocks))
+
+    for page_idx in range(start_idx, end_idx):
+        if page_idx >= len(page_blocks):
+            break
+        for block in page_blocks[page_idx]:
+            block_text = block.get("text", "").lower()
+            block_words = set(block_text.split())
+            overlap = chunk_words & block_words
+            if len(overlap) >= min(5, len(chunk_words) // 4):
+                bbox = block.get("bbox")
+                if bbox:
+                    rects.append(tuple(bbox))
+
+    return rects if rects else None
 
 
 @dataclass
@@ -234,11 +267,17 @@ class PdfChunkingProvider:
                     f"PDF chunker produced empty chunk at index={idx}"
                 )
             page_start, page_end = page_spans[idx]
+            rects = (
+                _extract_rects_for_chunk(chunk_text, page_start, page_end, extraction.page_blocks)
+                if extraction.page_blocks is not None and page_start is not None
+                else None
+            )
             artifacts.append(
                 ChunkArtifact(
                     content=chunk_text,
                     page_start=page_start,
                     page_end=page_end,
+                    rects=rects,
                 )
             )
 

--- a/src/litlake/providers/extraction.py
+++ b/src/litlake/providers/extraction.py
@@ -164,6 +164,7 @@ class ExtractionResult:
     text: str
     page_texts: list[str] | None = None
     metadata: dict[str, Any] | None = None
+    page_blocks: list[list[dict]] | None = None  # per-page PyMuPDF blocks with bbox coords
 
 
 def extract_html_text(html: str, *, require_trafilatura: bool = False) -> ExtractionResult:
@@ -240,11 +241,26 @@ class LocalPdfExtractionProvider:
         import fitz  # pymupdf
 
         raw_pages: list[str] = []
+        raw_blocks: list[list[dict]] = []
         with capture_mupdf_diagnostics(f"extract:{path}", log=logger):
             doc = fitz.open(str(path))
             try:
                 for page in doc:
                     raw_pages.append(page.get_text("text") or "")
+                    page_dict = page.get_text("dict")
+                    blocks = [
+                        {
+                            "bbox": b["bbox"],
+                            "text": "".join(
+                                span["text"]
+                                for line in b.get("lines", [])
+                                for span in line.get("spans", [])
+                            ),
+                        }
+                        for b in page_dict.get("blocks", [])
+                        if b.get("type") == 0  # type 0 = text block
+                    ]
+                    raw_blocks.append(blocks)
             finally:
                 doc.close()
 
@@ -260,6 +276,7 @@ class LocalPdfExtractionProvider:
         return ExtractionResult(
             text=normalized_text,
             page_texts=normalized_pages,
+            page_blocks=raw_blocks,
             metadata={"mode": "pymupdf", "normalized": True},
         )
 

--- a/src/litlake/server.py
+++ b/src/litlake/server.py
@@ -134,12 +134,14 @@ def _background_init(state: AppState) -> None:
                 ",".join(sorted(extraction_providers[0].supported_mime_types)),
             )
 
-            state.init_message = InitStatus.LOADING_EMBED
-            embedding_provider = _select_embedding_provider(state.settings)
+        # Model loading OUTSIDE the lock so sync_zotero_tool can proceed
+        state.init_message = InitStatus.LOADING_EMBED
+        embedding_provider = _select_embedding_provider(state.settings)
 
-            state.init_message = InitStatus.LOADING_RERANK
-            rerank_provider = _select_rerank_provider(state.settings)
+        state.init_message = InitStatus.LOADING_RERANK
+        rerank_provider = _select_rerank_provider(state.settings)
 
+        with state.conn_lock:
             register_ai_functions(state.conn, embedding_provider, rerank_provider)
 
         queue_policy = QueuePolicy(
@@ -285,20 +287,35 @@ def _resolve_claude_mcp_log_path() -> Path | None:
     annotations=ToolAnnotations(title="Sync Zotero Library", readOnlyHint=False, destructiveHint=False),
 )
 def sync_zotero_tool(ctx: Context) -> str:
+    import time
     state = _state(ctx)
-    with state.conn_lock:
-        result = sync_zotero(
-            state.conn,
-            queue_max_attempts=state.settings.queue_max_attempts,
-            explicit_db_path=state.settings.zotero_db_path,
-        )
+    last_exc = None
+    for attempt in range(10):
+        try:
+            sync_conn = connect_db(state.settings.paths.db_path)
+            try:
+                result = sync_zotero(
+                    sync_conn,
+                    queue_max_attempts=state.settings.queue_max_attempts,
+                    explicit_db_path=state.settings.zotero_db_path,
+                )
+            finally:
+                sync_conn.close()
 
-    if state.embedding_worker is not None:
-        state.embedding_worker.wake()
-    if state.extraction_worker is not None:
-        state.extraction_worker.wake()
+            if state.embedding_worker is not None:
+                state.embedding_worker.wake()
+            if state.extraction_worker is not None:
+                state.extraction_worker.wake()
 
-    return result
+            return result
+        except Exception as exc:
+            last_exc = exc
+            logger.warning("sync_zotero_tool attempt %d failed: %s", attempt, exc)
+            if "locked" in str(exc).lower():
+                time.sleep(2)
+                continue
+            raise
+    raise last_exc
 
 
 @mcp.tool(
@@ -447,6 +464,56 @@ def library_status(ctx: Context) -> str:
         },
     }
     return json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+
+@mcp.tool(
+    name="list_collections",
+    description=(
+        "List all Zotero collections (folders) with their hierarchy. "
+        "Returns collection names, IDs, and parent-child relationships. "
+        "Use collection_id with sql_search to filter references by collection, e.g.: "
+        "SELECT r.* FROM reference_items r "
+        "JOIN collection_items ci ON ci.reference_id = r.id "
+        "JOIN collections c ON c.id = ci.collection_id "
+        "WHERE c.id = <collection_id>"
+    ),
+    annotations=ToolAnnotations(title="List Zotero Collections", readOnlyHint=True, destructiveHint=False),
+)
+def list_collections(ctx: Context) -> str:
+    import json
+    state = _state(ctx)
+    with state.conn_lock:
+        collections = state.conn.execute(
+            """
+            SELECT
+                c.id,
+                c.zotero_collection_id,
+                c.name,
+                c.parent_zotero_collection_id,
+                p.id as parent_id,
+                p.name as parent_name,
+                COUNT(ci.reference_id) as item_count
+            FROM collections c
+            LEFT JOIN collections p ON p.zotero_collection_id = c.parent_zotero_collection_id
+            LEFT JOIN collection_items ci ON ci.collection_id = c.id
+            GROUP BY c.id
+            ORDER BY COALESCE(p.name, c.name), c.name
+            """
+        ).fetchall()
+
+    result = [
+        {
+            "id": int(row[0]),
+            "zotero_collection_id": row[1],
+            "name": row[2],
+            "parent_id": int(row[4]) if row[4] is not None else None,
+            "parent_name": row[5],
+            "item_count": int(row[6]),
+        }
+        for row in collections
+    ]
+    return json.dumps(result, indent=2, ensure_ascii=False)
 
 
 @mcp.tool(

--- a/src/litlake/server.py
+++ b/src/litlake/server.py
@@ -641,3 +641,165 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+
+@mcp.tool()
+def annotate_pdf_chunks(ctx: Context, 
+    reference_id: int,
+    chunk_indices: list[int],
+    color: tuple[float, float, float] = (1.0, 0.8, 0.0),
+    label: str = "",
+) -> CallToolResult:
+    """Highlight specific chunks in a PDF file using PyMuPDF.
+
+    Writes highlight annotations directly into the PDF file so they appear
+    when opening in Zotero or any PDF viewer. This is a temporary solution
+    until the Zotero 7 local API is available.
+
+    Zotero may be open. Reload the PDF in Zotero to show new annotations.
+    To edit annotations in Zotero, use File → Import Annotations after reloading.
+
+    Args:
+        reference_id: The reference item ID from the database.
+        chunk_indices: List of chunk_index values to highlight.
+        color: RGB color tuple (0.0-1.0) for the highlight. Default: yellow.
+        label: Optional label/comment to attach to each annotation.
+
+    SQL to find chunk indices:
+        SELECT d.chunk_index, d.content, json_extract(d.metadata_json, '$.loc.page_start') as page
+        FROM documents d
+        JOIN document_files df ON df.id = d.document_file_id
+        WHERE df.reference_id = <reference_id>
+        AND d.kind = 'fulltext_chunk'
+        ORDER BY d.chunk_index;
+    """
+    import fitz
+
+    state = _state(ctx)
+    db = connect_db(state.settings.paths.db_path)
+
+    row = db.execute(
+        "SELECT df.file_path FROM document_files df WHERE df.reference_id = ? AND df.mime_type = 'application/pdf' LIMIT 1",
+        (reference_id,),
+    ).fetchone()
+    if not row:
+        raise ValueError(f"No PDF found for reference_id={reference_id}")
+    file_path = row[0]
+
+    chunks = db.execute(
+        f"""
+        SELECT d.chunk_index, d.content,
+               json_extract(d.metadata_json, '$.loc.page_start') as page_start,
+               json_extract(d.metadata_json, '$.loc.page_end') as page_end
+        FROM documents d
+        JOIN document_files df ON df.id = d.document_file_id
+        WHERE df.reference_id = ? AND d.kind = 'fulltext_chunk'
+        AND d.chunk_index IN ({','.join('?' * len(chunk_indices))})
+        """,
+        (reference_id, *chunk_indices),
+    ).fetchall()
+
+    if not chunks:
+        raise ValueError(f"No chunks found for reference_id={reference_id} with indices={chunk_indices}")
+
+    doc = fitz.open(file_path)
+    highlighted = 0
+
+    try:
+        for chunk_index, content, page_start, page_end in chunks:
+            if page_start is None:
+                continue
+            start_idx = max(0, int(page_start) - 1)
+            end_idx = min(int(page_end) if page_end else int(page_start), len(doc) - 1)
+            words = content.split()
+            mid = len(words) // 2
+            search_text = " ".join(words[max(0, mid - 8):mid + 8]).strip()
+
+            for page_idx in range(start_idx, end_idx + 1):
+                page = doc[page_idx]
+                instances = page.search_for(search_text)
+                if not instances:
+                    search_text = " ".join(words[2:12]).strip()
+                    instances = page.search_for(search_text)
+                if instances:
+                    annot = page.add_highlight_annot(instances)
+                    annot.set_colors(stroke=color)
+                    if label:
+                        annot.set_info(content=label)
+                    annot.update()
+                    highlighted += 1
+                    break
+
+        doc.save(file_path, incremental=True, encryption=fitz.PDF_ENCRYPT_KEEP)
+    finally:
+        doc.close()
+
+    return CallToolResult(
+        content=[TextContent(type="text", text=f"Highlighted {highlighted}/{len(chunks)} chunks in {file_path}")]
+    )
+
+
+@mcp.tool()
+def annotate_quotes(
+    ctx: Context,
+    reference_id: int,
+    quotes: list[str],
+    color: tuple[float, float, float] = (0.0, 0.8, 0.0),
+    label: str = "",
+) -> CallToolResult:
+    """Highlight exact quote strings in a PDF file using PyMuPDF.
+
+    Searches for each quote string in the PDF and highlights all matches.
+    More precise than chunk-based annotation.
+
+    Note: quotes containing typographic characters (e.g. curly quotes, typographic
+    apostrophes, or em-dashes) may not be found if the PDF uses different encoding.
+    PyMuPDF will match up to the problematic character and stop. To work around
+    this, shorten the quote to end before the problematic character.
+    Example: use "the company changed its strategy" instead of
+    "the company changed its strategy’s outcome".
+
+    Args:
+        reference_id: The reference item ID from the database.
+        quotes: List of exact quote strings to search for and highlight.
+        color: RGB color tuple (0.0-1.0). Default: green.
+        label: Optional comment to attach to each annotation.
+    """
+    import fitz
+
+    state = _state(ctx)
+    db = connect_db(state.settings.paths.db_path)
+
+    row = db.execute(
+        "SELECT file_path FROM document_files WHERE reference_id = ? AND mime_type = 'application/pdf' LIMIT 1",
+        (reference_id,),
+    ).fetchone()
+    if not row:
+        raise ValueError(f"No PDF found for reference_id={reference_id}")
+    file_path = row[0]
+
+    doc = fitz.open(file_path)
+    results = []
+
+    try:
+        for quote in quotes:
+            found = False
+            for page in doc:
+                instances = page.search_for(quote)
+                if instances:
+                    annot = page.add_highlight_annot(instances)
+                    annot.set_colors(stroke=color)
+                    if label:
+                        annot.set_info(content=label)
+                    annot.update()
+                    found = True
+                    break
+            results.append(f"{'✅' if found else '❌'} {quote[:60]}...")
+
+        doc.save(file_path, incremental=True, encryption=fitz.PDF_ENCRYPT_KEEP)
+    finally:
+        doc.close()
+
+    return CallToolResult(
+        content=[TextContent(type="text", text="\n".join(results))]
+    )

--- a/src/litlake/sync.py
+++ b/src/litlake/sync.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from litlake.db import enqueue_job
 from litlake.providers.extraction import SUPPORTED_EXTRACTION_MIME_TYPES, extract_html_text
-from litlake.zotero import ZoteroAnnotation, ZoteroItem, ZoteroReader
+from litlake.zotero import ZoteroAnnotation, ZoteroCollection, ZoteroCollectionMembership, ZoteroItem, ZoteroReader
 
 
 def _to_json(value: dict[str, Any] | None) -> str | None:
@@ -301,6 +301,117 @@ def _upsert_note_documents(
     return counts
 
 
+
+def _sync_collections(
+    conn: sqlite3.Connection,
+    collections: list[ZoteroCollection],
+    memberships: list[ZoteroCollectionMembership],
+    zotero_key_to_reference_id: dict[str, int],
+) -> None:
+    """Upsert Zotero collections and their item memberships into Lit Lake DB."""
+
+    # Upsert collections
+    for col in collections:
+        existing = conn.execute(
+            "SELECT id FROM collections WHERE zotero_collection_id = ?",
+            (col.collection_id,)
+        ).fetchone()
+        if existing:
+            conn.execute(
+                """
+                UPDATE collections
+                SET name = ?, parent_zotero_collection_id = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE zotero_collection_id = ?
+                """,
+                (col.name, col.parent_collection_id, col.collection_id),
+            )
+        else:
+            conn.execute(
+                """
+                INSERT INTO collections (zotero_collection_id, zotero_key, name, parent_zotero_collection_id)
+                VALUES (?, ?, ?, ?)
+                """,
+                (col.collection_id, col.key, col.name, col.parent_collection_id),
+            )
+
+    # Rebuild collection_items from scratch (simple & correct)
+    conn.execute("DELETE FROM collection_items")
+
+    # Build lookup: zotero_item_id -> reference_id via zotero_key
+    # We need zotero_item_id -> zotero_key mapping from Zotero DB
+    # memberships use item_id (Zotero internal), we need reference_id
+    # Use reference_external_ids to map zotero item key -> reference_id
+    # But memberships only have item_id, not key — we need to join via reference_external_ids source_id
+    # source_id in reference_items = zotero key; in reference_external_ids scheme='zotero_key' value=key
+    # We stored zotero item_id nowhere directly — use source_id on reference_items which is the key
+    # We need item_id -> key mapping: query Zotero DB for that
+
+    # Build collection_id lookup
+    col_id_map = {}
+    for row in conn.execute("SELECT id, zotero_collection_id FROM collections").fetchall():
+        col_id_map[int(row[1])] = int(row[0])
+
+    # Build zotero_item_id -> reference_id map via reference_items.source_id
+    # reference_items.source_id = zotero item key (string)
+    # memberships have item_id (integer) — we need a bridge
+    # Query reference_external_ids: scheme='zotero_key', value=item_key
+    # But we only have item_id integers in memberships, not keys
+    # Solution: store item_id->key mapping from ZoteroReader
+    pass  # handled below via zotero_item_id_to_reference_id passed in
+
+
+def _sync_collections_with_ids(
+    conn: sqlite3.Connection,
+    collections: list[ZoteroCollection],
+    memberships: list[ZoteroCollectionMembership],
+    zotero_item_id_to_reference_id: dict[int, int],
+) -> None:
+    """Upsert Zotero collections and their item memberships into Lit Lake DB."""
+
+    # Upsert collections
+    for col in collections:
+        existing = conn.execute(
+            "SELECT id FROM collections WHERE zotero_collection_id = ?",
+            (col.collection_id,)
+        ).fetchone()
+        if existing:
+            conn.execute(
+                """
+                UPDATE collections
+                SET name = ?, parent_zotero_collection_id = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE zotero_collection_id = ?
+                """,
+                (col.name, col.parent_collection_id, col.collection_id),
+            )
+        else:
+            conn.execute(
+                """
+                INSERT INTO collections (zotero_collection_id, zotero_key, name, parent_zotero_collection_id)
+                VALUES (?, ?, ?, ?)
+                """,
+                (col.collection_id, col.key, col.name, col.parent_collection_id),
+            )
+
+    # Rebuild collection_items
+    conn.execute("DELETE FROM collection_items")
+    col_id_map = {
+        int(row[1]): int(row[0])
+        for row in conn.execute("SELECT id, zotero_collection_id FROM collections").fetchall()
+    }
+    for membership in memberships:
+        collection_db_id = col_id_map.get(membership.collection_id)
+        reference_id = zotero_item_id_to_reference_id.get(membership.item_id)
+        if collection_db_id is None or reference_id is None:
+            continue
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO collection_items (collection_id, reference_id)
+            VALUES (?, ?)
+            """,
+            (collection_db_id, reference_id),
+        )
+
+
 def sync_zotero(
     conn: sqlite3.Connection,
     *,
@@ -309,6 +420,7 @@ def sync_zotero(
 ) -> str:
     reader = ZoteroReader(explicit_db_path)
     items = reader.get_items()
+    collections, memberships = reader.get_collections()
 
     existing_map_rows = conn.execute(
         "SELECT value, reference_id FROM reference_external_ids WHERE scheme = 'zotero_key'"
@@ -406,6 +518,11 @@ def sync_zotero(
         note_counts.updated += note_deltas.updated
         note_counts.unchanged += note_deltas.unchanged
 
+    conn.commit()
+
+    # Sync collections
+    zotero_item_id_to_reference_id = {item.item_id: existing_map[item.key] for item in items if item.key in existing_map}
+    _sync_collections_with_ids(conn, collections, memberships, zotero_item_id_to_reference_id)
     conn.commit()
 
     embeddable_kinds = ("title", "abstract", "fulltext_chunk", "annotation", "note")

--- a/src/litlake/zotero.py
+++ b/src/litlake/zotero.py
@@ -59,6 +59,21 @@ class ZoteroItem:
     notes: list[ZoteroNote] = field(default_factory=list)
 
 
+
+@dataclass
+class ZoteroCollection:
+    collection_id: int
+    key: str
+    name: str
+    parent_collection_id: int | None
+
+
+@dataclass
+class ZoteroCollectionMembership:
+    collection_id: int
+    item_id: int
+
+
 class ZoteroReader:
     def __init__(self, db_path: str | None = None):
         self.db_path = self._find_db_path(db_path)
@@ -91,6 +106,48 @@ class ZoteroReader:
         if not full_path.exists():
             return None
         return str(full_path)
+
+    def get_collections(self) -> tuple[list[ZoteroCollection], list[ZoteroCollectionMembership]]:
+        conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+
+        collection_rows = conn.execute(
+            """
+            SELECT collectionID, key, collectionName, parentCollectionID
+            FROM collections
+            ORDER BY collectionID
+            """
+        ).fetchall()
+
+        collections = [
+            ZoteroCollection(
+                collection_id=int(row[0]),
+                key=row[1],
+                name=row[2],
+                parent_collection_id=int(row[3]) if row[3] is not None else None,
+            )
+            for row in collection_rows
+        ]
+
+        membership_rows = conn.execute(
+            """
+            SELECT collectionID, itemID
+            FROM collectionItems
+            ORDER BY collectionID, itemID
+            """
+        ).fetchall()
+
+        memberships = [
+            ZoteroCollectionMembership(
+                collection_id=int(row[0]),
+                item_id=int(row[1]),
+            )
+            for row in membership_rows
+        ]
+
+        conn.close()
+        return collections, memberships
+
 
     def get_items(self) -> list[ZoteroItem]:
         conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
@@ -274,7 +331,27 @@ class ZoteroReader:
 __all__ = [
     "ZoteroAttachment",
     "ZoteroAnnotation",
+    "ZoteroCollection",
+    "ZoteroCollectionMembership",
     "ZoteroItem",
     "ZoteroNote",
     "ZoteroReader",
 ]
+
+
+@dataclass
+class ZoteroCollection:
+    collection_id: int
+    key: str
+    name: str
+    parent_collection_id: int | None
+
+
+@dataclass 
+class ZoteroCollectionMembership:
+    collection_id: int
+    item_id: int
+
+
+def _get_collections_patch():
+    pass  # placeholder - see next step


### PR DESCRIPTION
**feat: PDF annotation support via PyMuPDF**

Adds two new MCP tools for writing highlight annotations directly into PDF files, as a temporary solution until the Zotero write-back API is ready (see #11).

**New tools:**
- `annotate_pdf_chunks` — highlights chunks by index, useful for semantic search results
- `annotate_quotes` — highlights exact quote strings, more precise for known text passages

**Behaviour:**
- Annotations are written directly into the PDF via PyMuPDF
- Zotero can be open; reload the PDF to see annotations
- Use File → Import Annotations in Zotero to make them editable
- Comments/popup text supported via `label` parameter
- Zotero tags not supported without the Zotero API
- Typographic characters (curly quotes, em-dashes) in quote strings may cause partial matches — shorten the quote before the problematic character as a workaround

**Tested on:** Zotero 7, macOS, humanities PDF corpus