### PR TITLE
fix: preserve author order from Zotero

### DIFF
--- a/src/litlake/zotero.py
+++ b/src/litlake/zotero.py
@@ -116,6 +116,7 @@ class ZoteroReader:
                     FROM itemCreators ic
                     JOIN creators c ON ic.creatorID = c.creatorID
                     WHERE ic.itemID = i.itemID
+                    ORDER BY ic.orderIndex
                 ) as authors
             FROM items i
             JOIN itemTypes it ON i.itemTypeID = it.itemTypeID

--- a/src/litlake/zotero.py
+++ b/src/litlake/zotero.py
@@ -104,19 +104,21 @@ class ZoteroReader:
                 abstract_val.value as abstract,
                 SUBSTR(date_val.value, 1, 4) as date,
                 (
-                    SELECT GROUP_CONCAT(
-                        CASE
-                            WHEN c.firstName IS NOT NULL AND c.lastName IS NOT NULL
-                            THEN c.lastName || ', ' || c.firstName
-                            WHEN c.lastName IS NOT NULL
-                            THEN c.lastName
-                            ELSE NULL
-                        END, '; '
+                    SELECT GROUP_CONCAT(author_str, '; ')
+                    FROM (
+                        SELECT
+                            CASE
+                                WHEN c.firstName IS NOT NULL AND c.lastName IS NOT NULL
+                                THEN c.lastName || ', ' || c.firstName
+                                WHEN c.lastName IS NOT NULL
+                                THEN c.lastName
+                                ELSE NULL
+                            END AS author_str
+                        FROM itemCreators ic
+                        JOIN creators c ON ic.creatorID = c.creatorID
+                        WHERE ic.itemID = i.itemID
+                        ORDER BY ic.orderIndex
                     )
-                    FROM itemCreators ic
-                    JOIN creators c ON ic.creatorID = c.creatorID
-                    WHERE ic.itemID = i.itemID
-                    ORDER BY ic.orderIndex
                 ) as authors
             FROM items i
             JOIN itemTypes it ON i.itemTypeID = it.itemTypeID


### PR DESCRIPTION
## Summary
- The `GROUP_CONCAT` subquery in `zotero.py` that builds the `authors` string was missing `ORDER BY ic.orderIndex`, causing authors to appear in arbitrary order rather than the order stored in Zotero
- This resulted in incorrect first-author attribution (e.g., Park et al. 2025 appearing as Nimmo et al. 2025)
- Fix: add `ORDER BY ic.orderIndex` to the subquery

## Test plan
- [x] Verified against Zotero SQLite DB: without fix, Park et al. 2025 shows as "Nimmo, F.; Weber, R. C.; ..."; with fix, correctly shows "Park, R. S.; Berne, A.; ..."
- [ ] Re-sync Zotero after deploying fix to confirm `reference_items.authors` is corrected for all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)